### PR TITLE
Add human-readable summary based on yaml report

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Installation & Usage
     If you specify the `github_user` and `github_password` options 
     the report processor will create a Gist containing the log output 
     from the run. The Gist will be linked in the IRC notification.
+    If you specify the `parsed_reports_dir` option, and have `store` reports
+    enabled, a human-readable version of the yaml report will be saved on the
+    reportserver, instead of a Gist.
 
 4.  Copy `irc.yaml` to `/etc/puppet`.
     NOTE: Remove any configurations items you're not setting
@@ -41,6 +44,8 @@ Installation & Usage
         [master]
         report = true
         reports = irc
+        ### or if you enable :parsed_reports_dir
+        # reports = store,irc
         pluginsync = true
         [agent]
         report = true

--- a/irc.yaml
+++ b/irc.yaml
@@ -6,4 +6,4 @@
 :irc_join: true
 :github_password: 'password'
 :github_user: 'user'
-
+#:parsed_reports_dir: '/var/log/puppet-reports'


### PR DESCRIPTION
For cases where you don't want to expose your puppet reports on a public
service. Or when the public service stops working because you have too
many failed reports... :-/

A sample notification sent to IRC looks like this:

```
Puppet stable run failed at Mon May 13 15:25:03 2013. Summary at puppetmaster0:/var/log/puppet-reports/foobar123.vserver.example.com-0.640093941855566
```
