### PR TITLE
Added User-Agent header for gist api call.

### DIFF
--- a/lib/puppet/reports/irc.rb
+++ b/lib/puppet/reports/irc.rb
@@ -100,6 +100,7 @@ Puppet::Reports.register_report(:irc) do
         https.start {
           req = Net::HTTP::Post.new('/gists')
           req.basic_auth "#{CONFIG[:github_user]}", "#{CONFIG[:github_password]}"
+          req.add_field("User-Agent", "#{CONFIG[:github_user]}")
           req.content_type = 'application/json'
           req.body = JSON.dump({
             "files" => { "#{host}-#{Time.now.to_i.to_s}" => { "content" => output.join("\n") } },


### PR DESCRIPTION
To satisfy http://developer.github.com/v3/#user-agent-required

Otherwise, you get: 

unexpected token at 'Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.'
