### PR TITLE
add puppetlabs-pe_gem to Modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,4 +4,5 @@ license 'Apache 2.0'
 summary 'Report processor that notifies an IRC channel about failed Puppet runs'
 project_page 'https://github.com/jamtur01/puppet-irc'
 
+dependency 'puppetlabs-pe_gem', '>=0.0.1'
 dependency 'puppetlabs-stdlib', '>=3.0.0'


### PR DESCRIPTION
  if $::is_pe {
    $puppet_user        = 'pe-puppet'
    $puppet_confdir     = '/etc/puppetlabs/puppet'
    $gem_provider       = 'pe_gem'
}

This will fail on PE if the pe_gem module is not installed to extend the package type.
