### PR TITLE
beware the fake false!  all strings are true, even when they're not

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class irc::params {
   $parsed_reports_dir = undef
   $report_url         = undef
 
-  if $::is_pe {
+  if str2bool($::is_pe) {
     $puppet_user        = 'pe-puppet'
     $puppet_confdir     = '/etc/puppetlabs/puppet'
     $gem_provider       = 'pe_gem'


### PR DESCRIPTION
because params.pp did this:
if $::is_pe {
 ...

It decided EVERY puppetmaster was PE.  This code just wraps $::is_pe in a str2bool so that this code will work on an opensource puppetmaster.