### PR TITLE
Don't raise a Puppet::ParseError in a report

### DIFF
--- a/lib/puppet/reports/irc.rb
+++ b/lib/puppet/reports/irc.rb
@@ -18,7 +18,7 @@ end
 Puppet::Reports.register_report(:irc) do
 
   configfile = File.join([File.dirname(Puppet.settings[:config]), "irc.yaml"])
-  raise(Puppet::ParseError, "IRC report config file #{configfile} not readable") unless File.exist?(configfile)
+  raise "IRC report config file #{configfile} not readable" unless File.exist?(configfile)
   CONFIG = YAML.load_file(configfile)
 
   desc <<-DESC


### PR DESCRIPTION
Instructors were getting the following warning when the `irc.yaml` file
was inadvertently written to the wrong place.

```
Error: Could not send report: Error 400 on SERVER: Could not autoload puppet/reports/irc: Class Irc is already defined in Puppet::Reports
```

This appears to correct it. My best guess, having not crawled completely
through the code, is that instantiating a `Puppet::ParseError` somehow
causes more to be instantiated than expected.